### PR TITLE
Add zsh alternative installation path

### DIFF
--- a/ansible/mac.yml
+++ b/ansible/mac.yml
@@ -70,7 +70,7 @@
       dest=~/.zshrc
       line="source {{dev_env_dir}}/ansible/mac_profile"
       create=yes
-    when: ansible_env.SHELL == "/bin/zsh"
+    when: ansible_env.SHELL == "/bin/zsh" or ansible_env.SHELL == "/usr/local/bin/zsh"
 
   - name: Add Docker Machine Environment to .bash_profile
     lineinfile: >


### PR DESCRIPTION
Brew installed zsh path is located at "/usr/local/bin/zsh", the ansible play book fails to install profile to zsh if it is installed from brew.