### PR TITLE
fix ansible error caused by yml parsing

### DIFF
--- a/ansible/mac.yml
+++ b/ansible/mac.yml
@@ -80,6 +80,4 @@
       when: ansible_env.SHELL == "/bin/bash"
 
     - name: Create Docker Machine
-      command: >
-        "{{ dev_env_dir }}/bin/dev machine create
-        creates=~/.docker/machine/machines/dev/config.json"
+      command: "{{ dev_env_dir }}/bin/dev machine create creates=~/.docker/machine/machines/dev/config.json"


### PR DESCRIPTION
Getting the following error when running `dev update`:

```bash
TASK: [Create Docker Machine] *************************************************
failed: [127.0.0.1] => {"failed": true, "parsed": false}
Traceback (most recent call last):
  File "/Users/ben/.ansible/tmp/ansible-tmp-1446734692.81-71086681279911/command", line 2091, in <module>
    main()
  File "/Users/ben/.ansible/tmp/ansible-tmp-1446734692.81-71086681279911/command", line 206, in main
    args = shlex.split(args)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shlex.py", line 279, in split
    return list(lex)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shlex.py", line 269, in next
    token = self.get_token()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shlex.py", line 96, in get_token
    raw = self.read_token()
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/shlex.py", line 172, in read_token
    raise ValueError, "No closing quotation"
ValueError: No closing quotation


FATAL: all hosts have already failed -- aborting
```

This pull request fixes the issue.