### PR TITLE
dev update command updates homebrew itself

### DIFF
--- a/ansible/mac.yml
+++ b/ansible/mac.yml
@@ -12,6 +12,9 @@
       become: yes
       become_method: sudo
 
+    - name: Update Homebrew
+      homebrew: update_homebrew=yes
+
     - name: Tap Caskroom
       homebrew_tap: tap=caskroom/cask
 


### PR DESCRIPTION
I wanted to play with the latest versions of Docker & Docker Compose, and `dev update` wasn't pulling the latest.