### PR TITLE
Set dns options while creating the docker machine

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -76,7 +76,7 @@ HEREDOC
     elsif args[0] == 'resume'
       system('VBoxManage startvm dev --type headless')
     elsif args[0] == 'create'
-      system('docker-machine create --driver virtualbox dev')
+      system('docker-machine create --driver virtualbox --engine-opt dns=192.168.99.100 --engine-opt dns=8.8.8.8 --engine-opt dns=8.8.4.4 dev')
       system('docker-machine scp /usr/local/dev-env/docker/bootsync.sh dev:/tmp/bootsync.sh')
       system('docker-machine ssh dev "sudo mv /tmp/bootsync.sh /var/lib/boot2docker/bootsync.sh"')
       system('docker-machine restart dev')

--- a/docker/bootsync.sh
+++ b/docker/bootsync.sh
@@ -3,7 +3,5 @@ sudo umount /Users
 sudo /usr/local/etc/init.d/nfs-client start
 sleep 1
 sudo mount.nfs 192.168.99.1:/Users /Users -v -o rw,async,noatime,rsize=32768,wsize=32768,proto=udp,udp,nfsvers=3
-grep '\-\-dns' /var/lib/boot2docker/profile || {
-	echo 'EXTRA_ARGS="$EXTRA_ARGS --dns 192.168.99.100 --dns 8.8.8.8 --dns 8.8.4.4"' | sudo tee -a /var/lib/boot2docker/profile
-}
+
 echo -e "nameserver 8.8.8.8\nnameserver 8.8.4.4" | sudo tee /etc/resolv.conf


### PR DESCRIPTION
Instead of setting it in bootsync, we can use the `--engine-opt` param of docker-machine while creating the machine itself.