### PR TITLE
remove comment on name: Add NFS share to /etc/exports

### DIFF
--- a/ansible/mac.yml
+++ b/ansible/mac.yml
@@ -55,9 +55,7 @@
         line: "{{ item }}"
         create: yes
       with_items:
-        - '## Begin Dash Developer Environment ##'
         - '\"/Users\" 192.168.99.100 -alldirs -mapall=0:80'
-        - '## End Dash Developer Environment ##'
       become: yes
       become_method: sudo
       register: exports


### PR DESCRIPTION
Comment are throwing the following issues on ansible2.x

```
fatal: [127.0.0.1]: FAILED! => {"failed": true, "msg": "ERROR! privilege output closed while waiting for password prompt:\nBECOME-SUCCESS-bsepwvbtietrohydcmutdqigblhodfue\n{\"msg\": \"\", \"invocation\": {\"module_args\": {\"directory_mode\": null, \"force\": null, \"remote_src\": null, \"backrefs\": false, \"insertafter\": null, \"owner\": null, \"follow\": false, \"line\": \"\\\\\\\"/Users\\\\\\\" 192.168.99.100 -alldirs -mapall=0:80\", \"group\": null, \"insertbefore\": null, \"create\": true, \"setype\": null, \"content\": null, \"serole\": null, \"state\": \"present\", \"dest\": \"/etc/exports\", \"selevel\": null, \"regexp\": null, \"validate\": null, \"src\": null, \"seuser\": null, \"delimiter\": null, \"mode\": null, \"backup\": false}}, \"changed\": false, \"backup\": \"\"}\n"}
```