### PR TITLE
Add fish shell support

### DIFF
--- a/ansible/mac.yml
+++ b/ansible/mac.yml
@@ -79,5 +79,12 @@
         create: yes
       when: ansible_env.SHELL == "/bin/bash"
 
+    - name: Add Docker Machine Environment to .config/fish/config.fish
+      lineinfile:
+        dest: ~/.config/fish/config.fish
+        line: "source {{ dev_env_dir }}/ansible/mac_profile.fish"
+        create: yes
+      when: ansible_env.SHELL == "/usr/local/bin/fish"
+
     - name: Create Docker Machine
       command: "{{ dev_env_dir }}/bin/dev machine create creates=~/.docker/machine/machines/dev/config.json"

--- a/ansible/mac_profile
+++ b/ansible/mac_profile
@@ -1,4 +1,3 @@
 # Dash Developer Environment Profile
-# This file should be shell-agnostic
 export PATH=$PATH:/usr/local/dev-env/bin
 eval "$(dev machine env)"

--- a/ansible/mac_profile.fish
+++ b/ansible/mac_profile.fish
@@ -1,0 +1,3 @@
+# Dash Developer Environment Profile
+set -x PATH $PATH "/usr/local/dev-env/bin"
+eval (docker-machine env dev)


### PR DESCRIPTION
I know `ansible/mac_profile` was intended to be shell-agnostic, but I couldn't find a way to detect fish shell from within `ansible/mac_profile` :confused: 

Can't use an [`if` statement](https://fishshell.com/docs/current/tutorial.html#tut_conditionals), nor an [`and` / `&&`](https://fishshell.com/docs/current/tutorial.html#tut_combiners) since the syntax is different.