### PR TITLE
Use explicit `args` in 'Create Docker Machine'

### DIFF
--- a/ansible/mac.yml
+++ b/ansible/mac.yml
@@ -80,4 +80,6 @@
       when: ansible_env.SHELL == "/bin/bash"
 
     - name: Create Docker Machine
-      command: "{{ dev_env_dir }}/bin/dev machine create creates=~/.docker/machine/machines/dev/config.json"
+      command: "{{ dev_env_dir }}/bin/dev machine create"
+      args:
+        creates: "~/.docker/machine/machines/dev/config.json"


### PR DESCRIPTION
Use the `args` option (like http://docs.ansible.com/ansible/command_module.html#examples) to make it clear that `creates=~/.docker/machine/machines/dev/config.json` isn't a command line argument for `dev machine create`.