### PR TITLE
Use verbose option for `ansible-playbook`

### DIFF
--- a/bin/dev
+++ b/bin/dev
@@ -89,7 +89,7 @@ HEREDOC
 
   def update(args)
     system('cd /usr/local/dev-env && git fetch && git reset --hard origin/master')
-    system('ansible-playbook /usr/local/dev-env/ansible/mac.yml -i 127.0.0.1, --ask-become-pass')
+    system('ansible-playbook /usr/local/dev-env/ansible/mac.yml -i 127.0.0.1, --ask-become-pass --verbose')
   end
 
   def dash(args)


### PR DESCRIPTION
This makes more clear how ansible is modifying your system.

### Before

```
PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [127.0.0.1]

TASK [Check Sudo Password] *****************************************************
changed: [127.0.0.1]

TASK [Update Homebrew] *********************************************************
ok: [127.0.0.1]

TASK [Tap Caskroom] ************************************************************
ok: [127.0.0.1]

TASK [Install Caskroom] ********************************************************
ok: [127.0.0.1]

TASK [Install Virtualbox] ******************************************************
ok: [127.0.0.1]

TASK [Install Docker and Extras] ***********************************************
ok: [127.0.0.1] => (item=docker)
ok: [127.0.0.1] => (item=docker-machine)
ok: [127.0.0.1] => (item=docker-compose)

TASK [Create resolver directory] ***********************************************
ok: [127.0.0.1]

TASK [Create dev resolver file at /etc/resolver/dev] ***************************
ok: [127.0.0.1]

TASK [Add NFS share to /etc/exports] *******************************************
ok: [127.0.0.1]

TASK [Restart nfsd] ************************************************************
skipping: [127.0.0.1]

TASK [Add Docker Machine Environment to .zshrc] ********************************
skipping: [127.0.0.1]

TASK [Add Docker Machine Environment to .bash_profile] *************************
skipping: [127.0.0.1]

TASK [Create Docker Machine] ***************************************************
changed: [127.0.0.1]

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=11   changed=2    unreachable=0    failed=0
```

### After

```
PLAY ***************************************************************************

TASK [setup] *******************************************************************
ok: [127.0.0.1]

TASK [Check Sudo Password] *****************************************************
changed: [127.0.0.1] => {"changed": true, "cmd": ["ls"], "delta": "0:00:00.007029", "end": "2016-02-17 16:23:04.804182", "rc": 0, "start": "2016-02-17 16:23:04.797153", "stderr": "", "stdout": ".489454.padl\n.CFUserTextEncoding\n.DS_Store\n.Genymobile\n.PyCharm40\n.PyCharm50\n.Trash\n.android\n.ansible\n.antigen\n.antigen.zsh\n.atom\n.autoenv_authorized\n.autoenv_authorized.tmp\n.babel-cache\n.babel.json\n.bash_history\n.black-screen-state\n.boot2docker\n.boto\n.cache\n.cargo\n.codeintel\n.config\n.cordova\n.docker\n.dropbox\n.electron\n.fbPager.log\n.fbPager.pickle\n.fbPager.selection.pickle\n.fbPager.sh\n.fireball.keys\n.fisherman\n.gem\n.gitconfig\n.gitignore_global\n.gradle\n.greenkeeperrc\n.heroku\n.hgignore_global\n.homesick\n.lesshst\n.lldb\n.local\n.meteor\n.meteorsession\n.mrconfig\n.nanorc\n.netrc\n.node-gyp\n.node_repl_history\n.npm\n.npmrc\n.npmrc.elliottsj\n.npmrc.private\n.nvm\n.oracle_jre_usage\n.php_history\n.pip\n.plugman\n.pre-commit\n.pry_history\n.pyenv\n.pylint.d\n.pypirc\n.python_history\n.rbenv\n.rsvm\n.ssh\n.subversion\n.v8flags.3.14.5.9.spencerelliott.json\n.v8flags.4.2.77.21.spencerelliott.json\n.v8flags.4.5.103.30.spencerelliott.json\n.v8flags.4.5.103.33.spencerelliott.json\n.v8flags.4.5.103.35.spencerelliott.json\n.vagrant.d\n.viminfo\n.wakatime.cfg\n.wakatime.db\n.wakatime.log\n.zcompdump\n.zprofile\n.zsh_history\n.zshrc\nApplications\nDesktop\nDocuments\nDownloads\nDropbox\nGitHub\nGoogle Drive\nLibrary\nMovies\nMusic\nPictures\nPublic\nSites\nVirtualBox VMs\ndevserver.retry\nmobile_application_server.retry\nmulti_event_app_server.retry\nprovision_multi_event_app_server.retry\nprovision_thumbor.retry\nthumbor_server.retry", "stdout_lines": [".489454.padl", ".CFUserTextEncoding", ".DS_Store", ".Genymobile", ".PyCharm40", ".PyCharm50", ".Trash", ".android", ".ansible", ".antigen", ".antigen.zsh", ".atom", ".autoenv_authorized", ".autoenv_authorized.tmp", ".babel-cache", ".babel.json", ".bash_history", ".black-screen-state", ".boot2docker", ".boto", ".cache", ".cargo", ".codeintel", ".config", ".cordova", ".docker", ".dropbox", ".electron", ".fbPager.log", ".fbPager.pickle", ".fbPager.selection.pickle", ".fbPager.sh", ".fireball.keys", ".fisherman", ".gem", ".gitconfig", ".gitignore_global", ".gradle", ".greenkeeperrc", ".heroku", ".hgignore_global", ".homesick", ".lesshst", ".lldb", ".local", ".meteor", ".meteorsession", ".mrconfig", ".nanorc", ".netrc", ".node-gyp", ".node_repl_history", ".npm", ".npmrc", ".npmrc.elliottsj", ".npmrc.private", ".nvm", ".oracle_jre_usage", ".php_history", ".pip", ".plugman", ".pre-commit", ".pry_history", ".pyenv", ".pylint.d", ".pypirc", ".python_history", ".rbenv", ".rsvm", ".ssh", ".subversion", ".v8flags.3.14.5.9.spencerelliott.json", ".v8flags.4.2.77.21.spencerelliott.json", ".v8flags.4.5.103.30.spencerelliott.json", ".v8flags.4.5.103.33.spencerelliott.json", ".v8flags.4.5.103.35.spencerelliott.json", ".vagrant.d", ".viminfo", ".wakatime.cfg", ".wakatime.db", ".wakatime.log", ".zcompdump", ".zprofile", ".zsh_history", ".zshrc", "Applications", "Desktop", "Documents", "Downloads", "Dropbox", "GitHub", "Google Drive", "Library", "Movies", "Music", "Pictures", "Public", "Sites", "VirtualBox VMs", "devserver.retry", "mobile_application_server.retry", "multi_event_app_server.retry", "provision_multi_event_app_server.retry", "provision_thumbor.retry", "thumbor_server.retry"], "warnings": []}

TASK [Update Homebrew] *********************************************************
ok: [127.0.0.1] => {"changed": false, "msg": "Homebrew already up-to-date."}

TASK [Tap Caskroom] ************************************************************
ok: [127.0.0.1] => {"changed": false, "msg": "added: 0, unchanged: 1"}

TASK [Install Caskroom] ********************************************************
ok: [127.0.0.1] => {"changed": false, "msg": "Package is already upgraded: brew-cask"}

TASK [Install Virtualbox] ******************************************************
ok: [127.0.0.1] => {"changed": false, "msg": "Cask already installed: virtualbox"}

TASK [Install Docker and Extras] ***********************************************
ok: [127.0.0.1] => (item=docker) => {"changed": false, "item": "docker", "msg": "Package is already upgraded: docker"}
ok: [127.0.0.1] => (item=docker-machine) => {"changed": false, "item": "docker-machine", "msg": "Package is already upgraded: docker-machine"}
ok: [127.0.0.1] => (item=docker-compose) => {"changed": false, "item": "docker-compose", "msg": "Package is already upgraded: docker-compose"}

TASK [Create resolver directory] ***********************************************
ok: [127.0.0.1] => {"changed": false, "gid": 0, "group": "wheel", "mode": "0755", "owner": "root", "path": "/etc/resolver", "size": 102, "state": "directory", "uid": 0}

TASK [Create dev resolver file at /etc/resolver/dev] ***************************
ok: [127.0.0.1] => {"changed": false, "dest": "/etc/resolver/dev", "gid": 0, "group": "wheel", "mode": "0755", "owner": "root", "size": 44, "src": "/usr/local/dev-env/ansible/resolver-dev.conf", "state": "link", "uid": 0}

TASK [Add NFS share to /etc/exports] *******************************************
ok: [127.0.0.1] => {"changed": false, "msg": ""}

TASK [Restart nfsd] ************************************************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}

TASK [Add Docker Machine Environment to .zshrc] ********************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}

TASK [Add Docker Machine Environment to .bash_profile] *************************
skipping: [127.0.0.1] => {"changed": false, "skip_reason": "Conditional check failed", "skipped": true}

TASK [Add Docker Machine Environment to .config/fish/config.fish] **************
ok: [127.0.0.1] => {"backup": "", "changed": false, "msg": ""}

TASK [Create Docker Machine] ***************************************************
ok: [127.0.0.1] => {"changed": false, "cmd": "/usr/local/dev-env/bin/dev machine create", "rc": 0, "stderr": false, "stdout": "skipped, since /Users/spencerelliott/.docker/machine/machines/dev/config.json exists", "stdout_lines": ["skipped, since /Users/spencerelliott/.docker/machine/machines/dev/config.json exists"]}

PLAY RECAP *********************************************************************
127.0.0.1                  : ok=12   changed=1    unreachable=0    failed=0
```